### PR TITLE
Small rewordings to reduce "No databank" confusion

### DIFF
--- a/src/requires/baseclass.lua
+++ b/src/requires/baseclass.lua
@@ -208,7 +208,7 @@ function programClass(Nav, c, u, atlas, vBooster, hover, telemeter_1, antigrav, 
                     if valuesAreSet then
                         msg ("Loaded Saved Variables")
                     elseif not useTheseSettings then
-                        msg ("No Databank Saved Variables Found\nVariables will save to Databank on standing")
+                        msg ("Databank Found, No Saved Variables Found\nVariables will save to Databank on standing")
                         msgTimer = 5
                     end
                     if #SavedLocations>0 then customlocations = addTable(customlocations, SavedLocations) end


### PR DESCRIPTION
Reading is hard.  I can't tell you the number of times I've seen "No databank" only to think that my databank wasn't linked for some reason, yet it is and I would have seen that if I had just kept reading.  I thought it was just me until I've seen some streamers do it as well. This moves the negative word "no" from the beginning, enforcing the positive aspect that the databank has been found but there aren't any variables saved, yet. Adds 1 character, a comma, which hopefully won't break GFN conversion. -- Squizz