### PR TITLE
Fixes autopilot cruise speed display in space

### DIFF
--- a/src/requires/hudclass.lua
+++ b/src/requires/hudclass.lua
@@ -331,7 +331,7 @@ function HudClass(Nav, c, u, s, atlas, antigrav, hover, shield, warpdrive, weapo
             local label = "CRUISE"
             local u = "km/h"
             local value = flightValue
-            if string.find(flightStyle, "TRAVEL") or string.find(flightStyle, "AUTOPILOT") then
+            if throttleMode and (string.find(flightStyle, "TRAVEL") or string.find(flightStyle, "AUTOPILOT")) then
                 label = "THROT"
                 u = "%"
                 value = throt

--- a/src/requires/hudclass.lua
+++ b/src/requires/hudclass.lua
@@ -346,6 +346,9 @@ function HudClass(Nav, c, u, s, atlas, antigrav, hover, shield, warpdrive, weapo
                     </g>]], throtclass, throtPosX-7, throtPosY-50, throtPosX, throtPosY-50, throtPosX, throtPosY+50, throtPosX-7, throtPosY+50, (1 - mabs(throt)), 
                     throtPosX-10, throtPosY+50, throtPosX-15, throtPosY+53, throtPosX-15, throtPosY+47)
             end
+            if string.find(flightStyle, "AUTOPILOT") then
+                label = 'AP ' .. label
+            end
             newContent[#newContent + 1] = svgText(throtPosX+10, y1, label , "pbright txtstart")
             newContent[#newContent + 1] = svgText(throtPosX+10, y2, stringf("%.0f %s", value, u), "pbright txtstart")
             if inAtmo and AtmoSpeedAssist and throttleMode and ThrottleLimited then


### PR DESCRIPTION
When using autopilot in space, the cruise speed is incorrectly registered as a percentage, with the text showing "THROT" too.
This PR aims to fix that and shows the correct value instead. It also adds an "AP" prefix to make it clear those are autopilot values.